### PR TITLE
[COOK-1297] Modify 'port' attribute to be a String instead of an Integer

### DIFF
--- a/resources/unicorn.rb
+++ b/resources/unicorn.rb
@@ -23,7 +23,7 @@ include Chef::Resource::ApplicationBase
 attribute :preload_app, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :worker_processes, :kind_of => Integer, :default => [node['cpu']['total'].to_i * 4, 8].min
 attribute :before_fork, :kind_of => String, :default => 'sleep 1'
-attribute :port, :kind_of => Integer, :default => 8080
+attribute :port, :kind_of => String, :default => "8080"
 attribute :worker_timeout, :kind_of => Integer, :default => 60
 attribute :bundler, :kind_of => [TrueClass, FalseClass, NilClass], :default => nil
 


### PR DESCRIPTION
This change modifies the 'port' attribute to be a String, which allows you to configure unicorn to use a socket via the unicorn sub-resource LWRP. Example:

```
application "my_app" do
  path "/deploy/to/dir"
  owner "app-user"
  group "app-group"

  repository "http://git.example.com/my-app.git"
  branch "production"

  rails do
    # Rails-specific configuration
  end

  unicorn do
    port "/var/run/unicorn.sock"
  end
end
```

Note that the code in this pull request will _not_ work without pulling in the corresponding changes to the unicorn cookbook from https://github.com/opscode-cookbooks/unicorn/pull/2.
