### PR TITLE
COOK-1408 - Unicorn provider in refactored application_ruby does not use user & group set in parent application resource when creating runit service

### DIFF
--- a/providers/unicorn.rb
+++ b/providers/unicorn.rb
@@ -59,6 +59,9 @@ action :before_restart do
 
   runit_service new_resource.name do
     template_name 'unicorn'
+    owner new_resource.owner if new_resource.owner 
+    group new_resource.group if new_resource.group
+
     cookbook 'application_ruby'
     options(
       :app => new_resource,


### PR DESCRIPTION
Trivial patch to fix [COOK-1408](http://tickets.opscode.com/browse/COOK-1408).
