### PR TITLE
execute the default unicorn restart command as root

### DIFF
--- a/providers/unicorn.rb
+++ b/providers/unicorn.rb
@@ -31,7 +31,7 @@ action :before_compile do
     include_recipe "unicorn"
   end
 
-  if !new_resource.restart_command
+  unless new_resource.restart_command
     new_resource.restart_command do
       execute "/etc/init.d/#{new_resource.name} hup" do
         user "root"


### PR DESCRIPTION
Fixes [COOK-1481](http://tickets.opscode.com/browse/COOK-1481). runit requires that the hup command come from root, so this change makes sure it will.
