### PR TITLE
Fix for Chef::Exceptions::ValidationFailed for cookbook (passenger_apache2 provider)

### DIFF
--- a/providers/passenger_apache2.rb
+++ b/providers/passenger_apache2.rb
@@ -44,7 +44,7 @@ action :before_deploy do
   web_app new_resource.application.name do
     docroot "#{new_resource.application.path}/current/public"
     template new_resource.webapp_template || "#{new_resource.application.name}.conf.erb"
-    cookbook new_resource.cookbook_name
+    cookbook new_resource.cookbook_name.to_s
     server_name "#{new_resource.application.name}.#{node['domain']}"
     server_aliases new_resource.server_aliases
     log_dir node['apache']['log_dir']


### PR DESCRIPTION
Chef 10.12 and ruby 1.9.3

Force cookbook to be a string.

```
application "app_name_com" do
  ...
  passenger_apache2 do
  end
end
```

This would cause the following error.

[2012-09-08T18:14:14+00:00] FATAL: Chef::Exceptions::ValidationFailed: ruby_block[app_name_com before_deploy](/tmp/vagrant-chef-1/chef-solo-1/cookbooks/application/providers/default.rb line 107) had an error: Chef::Exceptions::ValidationFailed: application_ruby_passenger_apache2[app_name_com](qudos_com::default line 109) had an error: Chef::Exceptions::ValidationFailed: Option cookbook must be a kind of [String]!  You passed :app_name_com.

This fix is simple to force the proper behavior.
