### PR TITLE
name is missing in metadata.rb file

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "application_ruby"
 maintainer       "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Since the `name` was not in this metadata.rb file, `berkshelf` errors out saying `Cookbook 'application_ruby' not found in any of the default locations`
