### PR TITLE
Fixing COOK-2079

### DIFF
--- a/providers/passenger_apache2.rb
+++ b/providers/passenger_apache2.rb
@@ -34,7 +34,7 @@ action :before_compile do
     new_resource.server_aliases server_aliases
   end
 
-  new_resource.restart_command "touch #{new_resource.application.path}/current/tmp/restart.txt" unless new_resource.restart_command
+  new_resource.restart_command "mkdir -p #{new_resource.application.path}/current/tmp && touch #{new_resource.application.path}/current/tmp/restart.txt" unless new_resource.restart_command
 end
 
 action :before_deploy do


### PR DESCRIPTION
- add a `mkdir -p` to the restart command
