### PR TITLE
Add pid and after_fork options

### DIFF
--- a/providers/unicorn.rb
+++ b/providers/unicorn.rb
@@ -62,6 +62,8 @@ action :before_restart do
     preload_app new_resource.preload_app
     worker_processes new_resource.worker_processes
     before_fork new_resource.before_fork
+    after_fork new_resource.after_fork
+    pid new_resource.pid
   end
 
   runit_service new_resource.name do

--- a/resources/unicorn.rb
+++ b/resources/unicorn.rb
@@ -23,10 +23,13 @@ include Chef::Resource::ApplicationBase
 attribute :preload_app, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :worker_processes, :kind_of => Integer, :default => [node['cpu']['total'].to_i * 4, 8].min
 attribute :before_fork, :kind_of => String, :default => 'sleep 1'
+attribute :after_fork, :kind_of => String, :default => ''
+
 attribute :port, :kind_of => String, :default => "8080"
 attribute :worker_timeout, :kind_of => Integer, :default => 60
 attribute :bundler, :kind_of => [TrueClass, FalseClass, NilClass], :default => nil
 attribute :bundle_command, :kind_of => [String, NilClass], :default => nil
+attribute :pid, :kind_of => [String, NilClass], :default => nil
 
 def options(*args, &block)
   @options ||= Mash[:tcp_nodelay => true, :backlog => 100]


### PR DESCRIPTION
These options are supported by the most recent unicorn cookbook but were unsupported by the unicorn resource in the application_ruby cookbook.
