### PR TITLE
convert cookbook_name to string for database.yml

### DIFF
--- a/providers/rails.rb
+++ b/providers/rails.rb
@@ -166,7 +166,7 @@ def create_database_yml
 
   template "#{new_resource.path}/shared/database.yml" do
     source new_resource.database_template || "database.yml.erb"
-    cookbook new_resource.database_template ? new_resource.cookbook_name : "application_ruby"
+    cookbook new_resource.database_template ? new_resource.cookbook_name.to_s : "application_ruby"
     owner new_resource.owner
     group new_resource.group
     mode "644"


### PR DESCRIPTION
Same issue as https://github.com/opscode-cookbooks/application_ruby/pull/11 but fixed for the database.yml template when using "database_template" 
