### PR TITLE
[COOK-2363] set template names properly

### DIFF
--- a/providers/unicorn.rb
+++ b/providers/unicorn.rb
@@ -65,7 +65,8 @@ action :before_restart do
   end
 
   runit_service new_resource.name do
-    template_name 'unicorn'
+    run_template_name 'unicorn'
+    log_template_name 'unicorn'
     owner new_resource.owner if new_resource.owner
     group new_resource.group if new_resource.group
 


### PR DESCRIPTION
Use `run_template_name` and `log_template_name`.
