### PR TITLE
[COOK-2448] Allow environment to be set for unicorn and runit

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The `unicorn` sub-resource LWRP configures Unicorn to run the application.
 - before_fork: passed to the `unicorn_config` LWRP
 - port: passed to the `unicorn_config` LWRP
 - worker_timeout: passed to the `unicorn_config` LWRP
+- environment: hash with environment variables for the unicorn processes. Passed to the `runit_service` LWRP.
 
 memcached
 ---------

--- a/providers/unicorn.rb
+++ b/providers/unicorn.rb
@@ -69,6 +69,7 @@ action :before_restart do
     log_template_name 'unicorn'
     owner new_resource.owner if new_resource.owner
     group new_resource.group if new_resource.group
+    env new_resource.environment unless new_resource.environment.empty?
 
     cookbook 'application_ruby'
     options(

--- a/resources/unicorn.rb
+++ b/resources/unicorn.rb
@@ -27,6 +27,7 @@ attribute :port, :kind_of => String, :default => "8080"
 attribute :worker_timeout, :kind_of => Integer, :default => 60
 attribute :bundler, :kind_of => [TrueClass, FalseClass, NilClass], :default => nil
 attribute :bundle_command, :kind_of => [String, NilClass], :default => nil
+attribute :environment, :kind_of => Hash, :default => {}
 
 def options(*args, &block)
   @options ||= Mash[:tcp_nodelay => true, :backlog => 100]

--- a/templates/default/sv-unicorn-run.erb
+++ b/templates/default/sv-unicorn-run.erb
@@ -3,4 +3,4 @@
 cd <%= @options[:app].path %>/current
 
 exec 2>&1
-exec <%= node[:runit][:chpst_bin] %> -e <%= node[:runit][:sv_dir] %>/<%= @options[:app].application.name %>/env -u <%= @options[:app].owner %>:<%= @options[:app].group %> <%= @options[:bundler] ? "#{@options[:bundle_command]} exec" : '' %> <%= @options[:smells_like_rack] ? 'unicorn' : 'unicorn_rails' %> -E <%= @options[:rails_env] %> -c /etc/unicorn/<%= @options[:app].application.name %>.rb
+exec <%= node[:runit][:chpst_bin] %> <% if @options[:env_dir] %>-e <%= node[:runit][:sv_dir] %>/<%= @options[:app].application.name %>/env<% end %> -u <%= @options[:app].owner %>:<%= @options[:app].group %> <%= @options[:bundler] ? "#{@options[:bundle_command]} exec" : '' %> <%= @options[:smells_like_rack] ? 'unicorn' : 'unicorn_rails' %> -E <%= @options[:rails_env] %> -c /etc/unicorn/<%= @options[:app].application.name %>.rb

--- a/templates/default/sv-unicorn-run.erb
+++ b/templates/default/sv-unicorn-run.erb
@@ -3,4 +3,4 @@
 cd <%= @options[:app].path %>/current
 
 exec 2>&1
-exec <%= node[:runit][:chpst_bin] %> -u <%= @options[:app].owner %>:<%= @options[:app].group %> <%= @options[:bundler] ? "#{@options[:bundle_command]} exec" : '' %> <%= @options[:smells_like_rack] ? 'unicorn' : 'unicorn_rails' %> -E <%= @options[:rails_env] %> -c /etc/unicorn/<%= @options[:app].application.name %>.rb
+exec <%= node[:runit][:chpst_bin] %> -e <%= node[:runit][:sv_dir] %>/<%= @options[:app].application.name %>/env -u <%= @options[:app].owner %>:<%= @options[:app].group %> <%= @options[:bundler] ? "#{@options[:bundle_command]} exec" : '' %> <%= @options[:smells_like_rack] ? 'unicorn' : 'unicorn_rails' %> -E <%= @options[:rails_env] %> -c /etc/unicorn/<%= @options[:app].application.name %>.rb


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2448

This commit allows environment variables to be set for the unicorn process by using the env attribute in the runit resource.

It is specified by using the environment attribute in the unicorn resource, for example:

```ruby
application "some_app" do
  #...
  unicorn do
    environment(
      'VARIABLE' =>  'some-value'
    )
  end
end
