### PR TITLE
Moving Gem.default_bindir to end of path

### DIFF
--- a/providers/rails.rb
+++ b/providers/rails.rb
@@ -32,7 +32,7 @@ action :before_compile do
 
   new_resource.environment.update({
     "RAILS_ENV" => new_resource.environment_name,
-    "PATH" => [Gem.default_bindir, ENV['PATH']].join(':')
+    "PATH" => [ENV['PATH'], Gem.default_bindir].join(':')
   })
 
   new_resource.symlink_before_migrate.update({


### PR DESCRIPTION
This allows me to setup my environment using rvm and to have the correct bundle command executed during gem installation and migration commands.

Resolves (hopefully) http://tickets.opscode.com/browse/COOK-2550.  If I'm missing something just let me know on the issue.
