### PR TITLE
Let Unicorn know where to find the *current* Gemfile

### DIFF
--- a/providers/unicorn.rb
+++ b/providers/unicorn.rb
@@ -62,6 +62,11 @@ action :before_restart do
     preload_app new_resource.preload_app
     worker_processes new_resource.worker_processes
     before_fork new_resource.before_fork
+    if new_resource.bundler
+      gemfile_path = ::File.join(new_resource.path, 'current/Gemfile')
+      command = %Q(ENV['BUNDLE_GEMFILE'] = '#{gemfile_path}')
+      before_exec command
+    end
   end
 
   runit_service new_resource.name do


### PR DESCRIPTION
When using bundler and unicorn, we've had issues where unicorn would be trying to read an outdated Gemfile after a deployment from say `/var/apps/myapp/releases/c0ffee/Gemfile`, which causes the process to die until manually restarted. This patch provides the accepted fix of setting the environment's `BUNDLE_GEMFILE` variable to the version that lives under the latest symlink.
