### PR TITLE
[COOK-2806] Include passenger_apache2::default instead of mod_rails

### DIFF
--- a/providers/passenger_apache2.rb
+++ b/providers/passenger_apache2.rb
@@ -24,7 +24,7 @@ action :before_compile do
   include_recipe "apache2"
   include_recipe "apache2::mod_ssl"
   include_recipe "apache2::mod_rewrite"
-  include_recipe "passenger_apache2::mod_rails"
+  include_recipe "passenger_apache2"
 
   unless new_resource.server_aliases
     server_aliases = [ "#{new_resource.application.name}.#{node['domain']}", node['fqdn'] ]


### PR DESCRIPTION
[COOK-2806](http://tickets.opscode.com/browse/COOK-2806)

[COOK-2750](http://tickets.opscode.com/browse/COOK-2750) identifies the issue with `passenger_apache2::mod_rails` and recommends the removal of that recipe entirely.

As it states, `passenger_apache2::default` already includes `mod_rails` and would work fine.

(recreation of #27, but this time with the right author information)
