### PR TITLE
[COOK-2079] Attempting to touch restart.txt should not cause a chef-client run to fail.

### DIFF
--- a/providers/passenger_apache2.rb
+++ b/providers/passenger_apache2.rb
@@ -35,8 +35,12 @@ action :before_compile do
   end
 
   new_resource.restart_command do
-    directory "#{new_resource.application.path}/current/tmp"
-    execute "touch #{new_resource.application.path}/current/tmp/restart.txt"
+    directory "#{new_resource.application.path}/current/tmp" do
+      recursive true
+    end
+    file "#{new_resource.application.path}/current/tmp/restart.txt" do
+      action :touch
+    end
   end unless new_resource.restart_command
 
 end


### PR DESCRIPTION
Use a directory resource to ensure the directory exists/created and use an execute for the touch of restart.txt.

See also, https://github.com/opscode-cookbooks/application_ruby/pull/16

Bug ticket, http://tickets.opscode.com/browse/COOK-2079
