### PR TITLE
[COOK-3377] Adds a configurable wait time to runit scripts

### DIFF
--- a/providers/unicorn.rb
+++ b/providers/unicorn.rb
@@ -86,7 +86,8 @@ action :before_restart do
       :bundler => new_resource.bundler,
       :bundle_command => new_resource.bundle_command,
       :rails_env => new_resource.environment_name,
-      :smells_like_rack => ::File.exists?(::File.join(new_resource.path, "current", "config.ru"))
+      :smells_like_rack => ::File.exists?(::File.join(new_resource.path, "current", "config.ru")),
+			:runit_wait_time => new_resource.runit_wait_time
     )
   end
 

--- a/resources/unicorn.rb
+++ b/resources/unicorn.rb
@@ -38,6 +38,7 @@ attribute :stdout_path, :kind_of => [String, NilClass], :default => nil
 attribute :unicorn_command_line, :kind_of => [String, NilClass], :default => nil
 attribute :copy_on_write, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :enable_stats, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :runit_wait_time, :kind_of => Integer, :default => 7
 
 def options(*args, &block)
   @options ||= Mash[:tcp_nodelay => true, :backlog => 100]

--- a/templates/default/sv-unicorn-run.erb
+++ b/templates/default/sv-unicorn-run.erb
@@ -8,4 +8,5 @@ exec <%= node[:runit][:chpst_bin] %> \
   <%= @options[:bundler] ? "#{@options[:bundle_command]} exec" : '' %> \
   <%= @options[:smells_like_rack] ? 'unicorn' : 'unicorn_rails' %> \
   -E <%= @options[:rails_env] %> \
-  -c /etc/unicorn/<%= @options[:app].application.name %>.rb
+	-c /etc/unicorn/<%= @options[:app].application.name %>.rb \
+	-w <%= @options[:runit_wait_time] %>


### PR DESCRIPTION
Addresses [COOK-3377](http://tickets.opscode.com/browse/COOK-3377). 

This adds a new attribute `runit_wait_time` to the `application_ruby`
provider that allows setting the time runit will wait before timing
out. It defaults to 7, which is runit's default.

It's possible that this should be moved to the runit_service LWRP, but this was the simplest fix at the time, as it only requires 3 lines to address.

Feedback appreciated.
