### PR TITLE
[COOK-3059] add bundle_options attribute to rails resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ Bundler will be run with:
 
 - gems: an Array of gems to install
 - bundler: if true, `bundler` will always be used; if false it will never be. Defaults to true if `gems` includes bundler
-- bundle_command: The command to execute when calling bundler commands.  Useful for specifing alternate commands such as RVM wrappers.  Defaults to `bundle`.
-- bundler_deployment: if true, Bundler will be run with the `--deployment` options. Defaults to true if a `Gemfile.lock` is present
+- bundle\_command: The command to execute when calling bundler commands.  Useful for specifing alternate commands such as RVM wrappers.  Defaults to `bundle`.
+- bundle\_options: additional options which will be appended to the end of the `bundle` command string. Useful for capturing the output to a file using the tee command
+e.g. `bundle_options "2>&1 | tee -a \some\log\file.log"` 
+- bundler\_deployment: if true, Bundler will be run with the `--deployment` options. Defaults to true if a `Gemfile.lock` is present
 - bundler\_without\_groups: an Array of additional Bundler groups to skip
 - database\_master\_role: if a role name is provided, a Chef search will be run to find a node with the role in the same environment as the current role. If a node is found, its IP address will be used when rendering the `database.yml` file, but see the "Database block parameters" section below
 - database\_template: the name of the template that will be rendered to create the `database.yml` file; if specified it will be looked up in the application cookbook. Defaults to "database.yml.erb" from this cookbook

--- a/providers/rails.rb
+++ b/providers/rails.rb
@@ -91,7 +91,10 @@ action :before_migrate do
       # Check for a Gemfile.lock
       bundler_deployment = ::File.exists?(::File.join(new_resource.release_path, "Gemfile.lock"))
     end
-    execute "#{bundle_command} install --path=vendor/bundle #{bundler_deployment ? "--deployment " : ""}--without #{common_groups}" do
+    command = "#{bundle_command} install --path=vendor/bundle --without #{common_groups}"
+    command += " --deployment" if bundler_deployment
+    command += " #{bundle_options}" if bundle_options
+    execute command do
       cwd new_resource.release_path
       user new_resource.owner
       environment new_resource.environment

--- a/resources/rails.rb
+++ b/resources/rails.rb
@@ -28,6 +28,7 @@ attribute :bundler, :kind_of => [NilClass, TrueClass, FalseClass], :default => n
 attribute :bundler_deployment, :kind_of => [NilClass, TrueClass, FalseClass], :default => nil
 attribute :bundler_without_groups, :kind_of => [Array], :default => []
 attribute :bundle_command, :kind_of => [String, NilClass], :default => "bundle"
+attribute :bundle_options, :kind_of => [String, NilClass], :default => nil
 attribute :precompile_assets, :kind_of => [NilClass, TrueClass, FalseClass], :default => nil
 attribute :use_omnibus_ruby, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :symlink_logs, :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3059

Allows arbitrary code to be appended to the bundler command string which is useful to be able to capture output to a specific log using the 'tee' command for example:

```
bundle_options "2>&1 | tee -a \some\log\file.log"
```
