### PR TITLE
Allow passing host to database resource

### DIFF
--- a/providers/rails.rb
+++ b/providers/rails.rb
@@ -176,7 +176,7 @@ def install_gems
 end
 
 def create_database_yml
-  host = new_resource.find_database_server(new_resource.database_master_role)
+  host = new_resource.database['host'] || new_resource.find_database_server(new_resource.database_master_role)
 
   template "#{new_resource.path}/shared/database.yml" do
     source new_resource.database_template || "database.yml.erb"


### PR DESCRIPTION
According to [COOK-3925](https://tickets.opscode.com/browse/COOK-3925) I've added `host` option to allow `knife solo` to specify database options.

Usage example:

``` ruby
application "my-app" do
  rails do
    database do
      host '127.0.0.1'
      database 'name'
      quorum 2
      replicas %w[Huey Dewey Louie]
    end
  end
end
```
