### PR TITLE
Fix method scoping on two sub-resources within the callback.

### DIFF
--- a/providers/passenger_apache2.rb
+++ b/providers/passenger_apache2.rb
@@ -34,11 +34,12 @@ action :before_compile do
     new_resource.server_aliases server_aliases
   end
 
+  r = new_resource
   new_resource.restart_command do
-    directory "#{new_resource.application.path}/current/tmp" do
+    directory "#{r.application.path}/current/tmp" do
       recursive true
     end
-    file "#{new_resource.application.path}/current/tmp/restart.txt" do
+    file "#{r.application.path}/current/tmp/restart.txt" do
       action :touch
     end
   end unless new_resource.restart_command


### PR DESCRIPTION
Looks like the run context for the deploy resource callbacks has changed (or this just never worked).
