### PR TITLE
fix deprecation warnings for Chef::DS?L::IncludeRecipe

### DIFF
--- a/providers/passenger_apache2.rb
+++ b/providers/passenger_apache2.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include Chef::Mixin::LanguageIncludeRecipe
+include Chef::DSL::IncludeRecipe
 
 action :before_compile do
 

--- a/providers/unicorn.rb
+++ b/providers/unicorn.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-include Chef::Mixin::LanguageIncludeRecipe
+include Chef::DSL::IncludeRecipe
 
 action :before_compile do
 


### PR DESCRIPTION
Fix for WARN: Chef::Mixin::LanguageIncludeRecipe is deprecated, use Chef::DSL::IncludeRecipe
instead.
