### PR TITLE
adding missing getter for bundle_options

### DIFF
--- a/providers/rails.rb
+++ b/providers/rails.rb
@@ -158,6 +158,10 @@ end
 
 protected
 
+def bundle_options
+  new_resource.bundle_options
+end
+
 def bundle_command
   new_resource.bundle_command
 end


### PR DESCRIPTION
This add a getter to bundle_option that appears to be left off when added.
