### PR TITLE
Rake install fix

### DIFF
--- a/providers/rails.rb
+++ b/providers/rails.rb
@@ -117,6 +117,7 @@ action :before_migrate do
   if new_resource.migration_command.include?('rake') && !gem_names.include?('rake')
     gem_package "rake" do
       action :install
+      not_if{ "which rake" }
     end
   end
 


### PR DESCRIPTION
Only install rake if not present. 

This prevents application_ruby converge errors related to:

http://bugs.ruby-lang.org/issues/5060
https://github.com/sstephenson/ruby-build/issues/386
