### PR TITLE
adding ruby_path to unicorn provider and resource to allow for runit scr...

### DIFF
--- a/providers/unicorn.rb
+++ b/providers/unicorn.rb
@@ -82,6 +82,7 @@ action :before_restart do
 
     cookbook 'application_ruby'
     options(
+      :ruby_path => new_resource.ruby_path,
       :app => new_resource,
       :bundler => new_resource.bundler,
       :bundle_command => new_resource.bundle_command,

--- a/resources/unicorn.rb
+++ b/resources/unicorn.rb
@@ -38,6 +38,7 @@ attribute :stdout_path, :kind_of => [String, NilClass], :default => nil
 attribute :unicorn_command_line, :kind_of => [String, NilClass], :default => nil
 attribute :copy_on_write, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :enable_stats, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :ruby_path, :kind_of => [String, NilClass], :default => nil
 
 def options(*args, &block)
   @options ||= Mash[:tcp_nodelay => true, :backlog => 100]

--- a/templates/default/sv-unicorn-run.erb
+++ b/templates/default/sv-unicorn-run.erb
@@ -2,6 +2,10 @@
 
 cd <%= @options[:app].path %>/current
 
+<%- if @options[:ruby_path] -%>
+  PATH=<%= @options[:ruby_path]%>:$PATH 
+<% end %>
+
 exec 2>&1
 exec <%= node[:runit][:chpst_bin] %> \
   -u <%= @options[:app].owner %>:<%= @options[:app].group %> \


### PR DESCRIPTION
Rbenv and i would guess RVM need the path to ruby bin to allow runit script to work this adds support to the LWRP to pass a ruby_path attribute that would get written to runit script template.