### PR TITLE
[COOK-4272] Add a gem_binary attribute to the rails resource

### DIFF
--- a/providers/rails.rb
+++ b/providers/rails.rb
@@ -117,6 +117,7 @@ action :before_migrate do
   if new_resource.migration_command.include?('rake') && !gem_names.include?('rake')
     gem_package "rake" do
       action :install
+      gem_binary new_resource.gem_binary if new_resource.gem_binary
     end
   end
 
@@ -173,6 +174,7 @@ def install_gems
     gem_package gem do
       action :install
       source src if src
+      gem_binary new_resource.gem_binary if new_resource.gem_binary
       version ver if ver && ver.length > 0
     end
   end

--- a/resources/rails.rb
+++ b/resources/rails.rb
@@ -24,6 +24,7 @@ attribute :database_master_role, :kind_of => [String, NilClass], :default => nil
 # Actually defaults to "database.yml.erb", but nil means it wasn't set by the user
 attribute :database_template, :kind_of => [String, NilClass], :default => nil
 attribute :gems, :kind_of => [Array, Hash], :default => []
+attribute :gem_binary, :kind_of => [String, NilClass], :default => nil
 attribute :bundler, :kind_of => [NilClass, TrueClass, FalseClass], :default => nil
 attribute :bundler_deployment, :kind_of => [NilClass, TrueClass, FalseClass], :default => nil
 attribute :bundler_without_groups, :kind_of => [Array], :default => []


### PR DESCRIPTION
With using multiple ruby versions on a system, it's nice to be able to control which ruby the gems are installed to.

**UPDATE**

I've created a ticket here:

https://tickets.opscode.com/browse/COOK-4272

There wasn't a component for this cookbook, so I just picked `gems`
