### PR TITLE
`bundler_without_groups` should take precedence over automated config

### DIFF
--- a/providers/rails.rb
+++ b/providers/rails.rb
@@ -83,8 +83,8 @@ action :before_migrate do
       to "#{new_resource.path}/shared/vendor_bundle"
     end
     common_groups = %w{development test cucumber staging production}
-    common_groups += new_resource.bundler_without_groups
     common_groups -= [new_resource.environment_name]
+    common_groups += new_resource.bundler_without_groups
     common_groups = common_groups.join(' ')
     bundler_deployment = new_resource.bundler_deployment
     if bundler_deployment.nil?


### PR DESCRIPTION
The README states:

> When running Bundler, unnecessary groups will be skipped. The list of groups
> to skip is determined with this algorithm:
> - start with this Array: development test cucumber staging production;
> - the group corresponding to the current environment will be removed from the
>   Array;
> - if the bundler_without_groups attribute is set, those groups will be added
>   to the Array.

yet, the current implementation prevented you from ignoring a group if it had
the same name as the current environment. This fixes that
