### PR TITLE
Have environment use the ssh wrapper if using a deploy key

### DIFF
--- a/providers/rails.rb
+++ b/providers/rails.rb
@@ -66,6 +66,7 @@ end
 action :before_migrate do
 
   symlink_logs if new_resource.symlink_logs
+  new_resource.environment['GIT_SSH'] = "#{new_resource.path}/deploy-ssh-wrapper" if new_resource.deploy_key
 
   if new_resource.bundler
     Chef::Log.info "Running bundle install"


### PR DESCRIPTION
This allows bundler to checkout gems from private git repositories, assuming your Gemfile specifies this with git:// rather than https:// and your deploy key also has access to the repository.
