### PR TITLE
Add def for bundle_options to fix NameError

### DIFF
--- a/providers/rails.rb
+++ b/providers/rails.rb
@@ -162,6 +162,10 @@ def bundle_command
   new_resource.bundle_command
 end
 
+def bundle_options
+  new_resource.bundle_options
+end
+
 def install_gems
   new_resource.gems.each do |gem, opt|
     if opt.is_a?(Hash)


### PR DESCRIPTION
A bug was introduced that makes the rails block fail due to bundle_options not being defined. This change defines bundle_options the same way as bundle_command is defined.
