### PR TITLE
Bump version to 3.0.3

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Deploys and configures Ruby-based applications"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.0.2"
+version          "3.0.3"
 
 %w{ unicorn apache2 passenger_apache2 }.each do |cb|
   depends cb


### PR DESCRIPTION
Running into issues having master be the same version as the 3.0.2 tag where the desired version is overwritten. Since new development has started a bump to the version makes sense.