### PR TITLE
add source_url attribute for chef supermarket

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,7 @@ maintainer       "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Deploys and configures Ruby-based applications"
+source_url       "https://github.com/poise/application_ruby"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "3.0.2"
 


### PR DESCRIPTION
Just added the [source_url attribute][1], so a link on supermarket.chef.io will appear to this repo.

[1]: https://docs.chef.io/config_rb_metadata.html