### PR TITLE
Added Ability to Bind Unicorn to Loopback Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ end
 
 * `path` – Base path for the application. *(name attribute)*
 * `port` – Port to listen on. *(default: 80)*
+* `address` – Address to bind to. *(default: 0.0.0.0)*
 * `service_name` – Name of the service to create. *(default: auto-detect)*
 # `user` – User to run the service as. *(default: application owner)*
 

--- a/lib/poise_application_ruby/resources/unicorn.rb
+++ b/lib/poise_application_ruby/resources/unicorn.rb
@@ -53,7 +53,7 @@ module PoiseApplicationRuby
         attribute(:port, kind_of: [String, Integer], default: 80)
         # @!attribute address
         #   Address to bind to.
-        attribute(:address, kind_of: [String, Integer], default: 0.0.0.0)
+        attribute(:address, kind_of: String, default: 0.0.0.0)
       end
 
       # Provider for `application_unicorn`.

--- a/lib/poise_application_ruby/resources/unicorn.rb
+++ b/lib/poise_application_ruby/resources/unicorn.rb
@@ -82,7 +82,7 @@ module PoiseApplicationRuby
         # Set service resource options.
         def service_options(resource)
           super
-          resource.ruby_command("unicorn --listen #{new_resource.address}:#{new_resource.port} #{configru_path}")
+          resource.ruby_command("unicorn --host #{new_resource.address} --port #{new_resource.port} #{configru_path}")
         end
       end
     end

--- a/lib/poise_application_ruby/resources/unicorn.rb
+++ b/lib/poise_application_ruby/resources/unicorn.rb
@@ -51,6 +51,9 @@ module PoiseApplicationRuby
         # @!attribute port
         #   Port to bind to.
         attribute(:port, kind_of: [String, Integer], default: 80)
+        # @!attribute address
+        #   Address to bind to.
+        attribute(:address, kind_of: [String, Integer], default: 0.0.0.0)
       end
 
       # Provider for `application_unicorn`.
@@ -79,7 +82,7 @@ module PoiseApplicationRuby
         # Set service resource options.
         def service_options(resource)
           super
-          resource.ruby_command("unicorn --port #{new_resource.port} #{configru_path}")
+          resource.ruby_command("unicorn --listen #{new_resource.address}:#{new_resource.port} #{configru_path}")
         end
       end
     end


### PR DESCRIPTION
Took a stab at trying to add an address attribute to the unicorn model.  The goal is to allow the user flexibility in binding unicorn to a specific address and not having to rely on the default of 0.0.0.0.