### PR TITLE
Prevent Database Secrets From Being Logged During Chef Run

### DIFF
--- a/lib/poise_application_ruby/resources/rails.rb
+++ b/lib/poise_application_ruby/resources/rails.rb
@@ -219,6 +219,7 @@ module PoiseApplicationRuby
             group new_resource.parent.group
             mode '640'
             content new_resource.database_config_content
+            sensitive true
           end
         end
 


### PR DESCRIPTION
__Why__

* chef run is outputing sensitive database secrets such as
  admin password, secure token, api keys, etc. to the shell and
  the log file.

__How__

* add sensitive = true, the same way secrets.yml configs are handled.